### PR TITLE
feat: Refactor module to single-repo pattern with configurable branch protection, and autolink support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,6 @@ repos:
     hooks:
       - id: terraform-docs-system
         name: "Terraform Docs"
-        args: ["markdown", "table", "--output-file", "README.md", "."]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.17.2

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ module "repository" {
 
 | Name | Type |
 |------|------|
-| [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
-| [github_repository_autolink_reference.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_autolink_reference) | resource |
-| [github_repository_ruleset.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
+| [github_repository.repository](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [github_repository_autolink_reference.autolink_reference](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_autolink_reference) | resource |
+| [github_repository_ruleset.ruleset](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
 
 ***
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   }
 }
 
-resource "github_repository" "this" {
+resource "github_repository" "repository" {
   allow_auto_merge            = var.allow_auto_merge
   allow_merge_commit          = var.allow_merge_commit
   allow_rebase_merge          = var.allow_rebase_merge
@@ -34,11 +34,11 @@ resource "github_repository" "this" {
   web_commit_signoff_required = var.web_commit_signoff_required
 }
 
-resource "github_repository_ruleset" "this" {
+resource "github_repository_ruleset" "ruleset" {
   count       = var.enable_default_ruleset ? 1 : 0
   enforcement = "active"
   name        = var.default_branch_name
-  repository  = github_repository.this.name
+  repository  = github_repository.repository.name
   target      = "branch"
 
   bypass_actors {
@@ -77,9 +77,9 @@ resource "github_repository_ruleset" "this" {
   }
 }
 
-resource "github_repository_autolink_reference" "this" {
+resource "github_repository_autolink_reference" "autolink_reference" {
   count               = var.autolink_reference_prefix != "" && var.autolink_reference_url_template != "" ? 1 : 0
-  repository          = github_repository.this.name
+  repository          = github_repository.repository.name
   key_prefix          = var.autolink_reference_prefix
   target_url_template = var.autolink_reference_url_template
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "repository_name" {
   description = "Repository name"
-  value       = github_repository.this.name
+  value       = github_repository.repository.name
 }
 
 output "repository_url" {
   description = "Repository URL"
-  value       = github_repository.this.html_url
+  value       = github_repository.repository.html_url
 }
 
 output "repository_id" {
   description = "Repository ID"
-  value       = github_repository.this.id
+  value       = github_repository.repository.id
 }


### PR DESCRIPTION
This PR refactors the GitHub repository module to adopt a single-repo input pattern and exposes all major repo and branch protection options as variables with sensible defaults.

I recommend reviewing the files themselves instead of the diffs.

[Slack thread](https://trussworks.slack.com/archives/CLNC1MUBS/p1748894806518179)